### PR TITLE
fixed issue #4 ISO C++ forbids initialization of member ‘init’ for

### DIFF
--- a/Core/AppFile/NBAppFile.cpp
+++ b/Core/AppFile/NBAppFile.cpp
@@ -430,6 +430,7 @@ void NBAppFile::parseDesktopFile() {
 NBAppsList::NBAppsList() {
 
 	clear();
+	__clearedOfDuplicates = false;
 };
 
 void NBAppsList::clear() {

--- a/Core/AppFile/NBAppFile.hpp
+++ b/Core/AppFile/NBAppFile.hpp
@@ -131,7 +131,7 @@ class NBAppsList {
 
 	private:
 		QList<NBAppFile> __appsList;
-		bool __clearedOfDuplicates = false;
+		bool __clearedOfDuplicates/* = false*/;
 };
 
 uint qHash( const NBAppFile &app );

--- a/Core/FSWatcher/NBFileSystemWatcher.cpp
+++ b/Core/FSWatcher/NBFileSystemWatcher.cpp
@@ -8,7 +8,11 @@
 
 NBFileSystemWatcher::NBFileSystemWatcher() : QThread() {
 
+	__stopWatch = false;
+	WD = -1;
+	buffer[ BUF_LEN ] = { 0 };
 	inotifyFD = inotify_init();
+	watchPath = QString();
 	if ( inotifyFD < 0 )
 		qCritical() << "Failed initialize inotify";
 };

--- a/Core/FSWatcher/NBFileSystemWatcher.hpp
+++ b/Core/FSWatcher/NBFileSystemWatcher.hpp
@@ -39,13 +39,13 @@ class NBFileSystemWatcher : public QThread {
 	private:
 		void waitForWatchEnded();
 
-		int inotifyFD = -1;
-		int WD = -1;
-		char buffer[ BUF_LEN ] = { 0 };
+		int inotifyFD/* = -1*/;
+		int WD/* = -1*/;
+		char buffer[ BUF_LEN ]/* = { 0 }*/;
 
-		QString watchPath = QString();
+		QString watchPath/* = QString()*/;
 
-		bool __stopWatch = false;
+		bool __stopWatch/* = false*/;
 
 	Q_SIGNALS :
 		void nodeCreated( QString );

--- a/Core/FileIO/NBFileIO.cpp
+++ b/Core/FileIO/NBFileIO.cpp
@@ -35,6 +35,9 @@ NBFileIO::NBFileIO() {
 	copiedSize = 0;
 	fTotalBytes = 0;
 	fWritten = 0;
+	wasCanceled = false;
+	isPaused = false;
+
 };
 
 void NBFileIO::setSources( QStringList sources ) {

--- a/Core/FileIO/NBFileIO.hpp
+++ b/Core/FileIO/NBFileIO.hpp
@@ -97,8 +97,8 @@ class NBFileIO : public QObject {
 
 		QString jobID;
 
-		bool wasCanceled = false;
-		bool isPaused = false;
+		bool wasCanceled/* = false*/;
+		bool isPaused/* = false*/;
 
 		NBIOMode::Mode mode;
 

--- a/Gui/Others/Settings/NBSettings.cpp
+++ b/Gui/Others/Settings/NBSettings.cpp
@@ -279,7 +279,7 @@ void NBSettings::reload() {
 	if ( not defaultSettings->init )
 		defaultInstance();
 
-	if ( not settings->init )
+	if ( not settings->init ) // call to defaultInstance set to false init var so dont ninit in header
 		instance();
 
 	QSettings gSettings( "NewBreeze", "NewBreeze" );

--- a/Gui/Others/Settings/NBSettings.hpp
+++ b/Gui/Others/Settings/NBSettings.hpp
@@ -120,7 +120,7 @@ class NBSettings {
 	private:
 		NBSettings() {};
 
-		bool init = false;
+		bool init/* = false*/;
 
 		static NBSettings *settings;
 		static NBSettings *defaultSettings;


### PR DESCRIPTION
fixed issue #4 ISO C++ forbids initialization of member ‘init’ for any compiler, closes #4
