### PR TITLE
some more initializers in some headers, and qt 4.6/4.7 compatibility backguard

### DIFF
--- a/Core/AppFile/NBAppFile.hpp
+++ b/Core/AppFile/NBAppFile.hpp
@@ -131,7 +131,7 @@ class NBAppsList {
 
 	private:
 		QList<NBAppFile> __appsList;
-		bool __clearedOfDuplicates = false;
+		bool __clearedOfDuplicates;
 };
 
 uint qHash( const NBAppFile &app );

--- a/Core/MimeHandler/NBMimeDatabase.cpp
+++ b/Core/MimeHandler/NBMimeDatabase.cpp
@@ -518,7 +518,7 @@ QMimeType QMimeDatabase::mimeTypeForData(QIODevice *device) const
 */
 QMimeType QMimeDatabase::mimeTypeForUrl(const QUrl &url) const
 {
-    if (url.isLocalFile())
+    if (url.scheme().compare( "file", Qt::CaseInsensitive ) == 0)
         return mimeTypeForFile(url.toLocalFile());
 
     const QString scheme = url.scheme();

--- a/Core/MimeHandler/NBMimeType.cpp
+++ b/Core/MimeHandler/NBMimeType.cpp
@@ -276,7 +276,10 @@ QString QMimeType::comment() const
 
     QStringList languageList;
     languageList << QLocale::system().name();
+    /*temporally workaround until i learn the code behind the qt 4.8 api for locales */
+#if QT_VERSION >= 0x040800
     languageList << QLocale::system().uiLanguages();
+#endif
     Q_FOREACH (const QString &language, languageList) {
         const QString lang = language == QLatin1String("C") ? QLatin1String("en_US") : language;
         const QString comm = d->localeComments.value(lang);


### PR DESCRIPTION
- ...in previusly commits, so fixed #4 property (still more in filename handler) in NBAppFile.hpp
- some more initializers in some headers, and qt 4.6/4.7 compatibility backguard in NBMimeDatabase.cpp
- temporally workaround for qt 4.6/4.7 compat in locale lister for NBMimeType.cpp
